### PR TITLE
Search: fix cutoff logic

### DIFF
--- a/search.go
+++ b/search.go
@@ -127,6 +127,7 @@ func searchAlphaBeta(
 		searchDepth = QUIESCENT_SEARCH_DEPTH
 	}
 
+FindBestMove:
 	for i := 0; i < len(moveOrdering); i++ {
 		for _, move := range moveOrdering[i] {
 			if move.IsCastle() && !boardState.TestCastleLegality(move) {
@@ -175,7 +176,7 @@ func searchAlphaBeta(
 					hashCutoffs++
 				}
 				cutoffs++
-				break
+				break FindBestMove
 			}
 		}
 


### PR DESCRIPTION
When we hit the alpha-beta cutoff we need to stop looking at moves.  When I moved the search logic to double-loop over the moveOrdering list I just had it breaking out of the inner loop.