### PR TITLE
Move generation: remove CAPTURE_MASK

### DIFF
--- a/board.go
+++ b/board.go
@@ -241,6 +241,7 @@ type BoardState struct {
 	// Internal structures to allow unmaking moves
 	captureStack     byteStack
 	boardInfoHistory [MAX_MOVES]BoardInfo
+	wasCapture       [MAX_MOVES]bool
 	moveIndex        int // 0-based and increases after every move
 
 	// Zobrist hash indices
@@ -602,21 +603,6 @@ func CreateMovesFromBitboard(sq byte, moveBoard uint64) []Move {
 	return moves
 }
 
-// CreateCapturesFromBitboard transforms a bitboard and a square to a slice of moves
-// with the capture flag set.
-// TODO: figure out how to reduce code duplication with CreateMovesFromBitboard (?)
-func CreateCapturesFromBitboard(sq byte, moveBoard uint64) []Move {
-	moves := make([]Move, 0)
-
-	for moveBoard != 0 {
-		destSq := byte(bits.TrailingZeros64(moveBoard))
-		moveBoard ^= 1 << destSq
-		moves = append(moves, CreateCapture(sq, destSq))
-	}
-
-	return moves
-}
-
 func sanityCheckBitboards(move Move, boardState *BoardState) {
 	for row := byte(0); row < 8; row++ {
 		for col := byte(0); col < 8; col++ {
@@ -674,7 +660,7 @@ func sanityCheckBitboards(move Move, boardState *BoardState) {
 			if isError {
 				fmt.Println(boardState.ToString())
 				fmt.Println(BitboardToString(bitboard))
-				fmt.Println(MoveToString(move))
+				fmt.Println(MoveToString(move, boardState))
 				panic(message)
 			}
 		}

--- a/board_move_test.go
+++ b/board_move_test.go
@@ -47,7 +47,7 @@ func TestApplyBlackPawnSingleMove(t *testing.T) {
 	emptyBoard.SetPieceAtSquare(SQUARE_B6, WHITE_MASK|ROOK_MASK)
 	emptyBoard.offsetToMove = BLACK_OFFSET
 
-	emptyBoard.ApplyMove(CreateCapture(SQUARE_A7, SQUARE_B6))
+	emptyBoard.ApplyMove(CreateMove(SQUARE_A7, SQUARE_B6))
 
 	assert.Equal(t, emptyBoard.boardInfo.enPassantTargetSquare, uint8(0))
 }
@@ -99,7 +99,7 @@ func TestApplyCapture(t *testing.T) {
 	assert.Equal(t, SetBitboard(0, SQUARE_A2), testBoard.bitboards.piece[BITBOARD_PAWN_OFFSET])
 	assert.Equal(t, SetBitboard(0, SQUARE_B3), testBoard.bitboards.piece[BITBOARD_ROOK_OFFSET])
 
-	m := CreateCapture(SQUARE_A2, SQUARE_B3)
+	m := CreateMove(SQUARE_A2, SQUARE_B3)
 	testBoard.ApplyMove(m)
 
 	assert.Equal(t, EMPTY_SQUARE, testBoard.PieceAtSquare(SQUARE_A2))
@@ -137,8 +137,8 @@ func TestApplyCaptureTwice(t *testing.T) {
 	assert.Equal(t, SetBitboard(0, SQUARE_B3), testBoard.bitboards.piece[BITBOARD_ROOK_OFFSET])
 	assert.Equal(t, SetBitboard(0, SQUARE_C5), testBoard.bitboards.piece[BITBOARD_KNIGHT_OFFSET])
 
-	m1 := CreateCapture(SQUARE_A2, SQUARE_B3)
-	m2 := CreateCapture(SQUARE_C5, SQUARE_B3)
+	m1 := CreateMove(SQUARE_A2, SQUARE_B3)
+	m2 := CreateMove(SQUARE_C5, SQUARE_B3)
 
 	testBoard.ApplyMove(m1)
 

--- a/check_detection_test.go
+++ b/check_detection_test.go
@@ -61,7 +61,7 @@ func TestBlackKingDoesNotCheckWhiteKing(t *testing.T) {
 	var fen string = "r6r/1b2k1bq/8/8/7B/8/8/R3K2R b QK - 3 2"
 	testBoard, _ := CreateBoardStateFromFENString(fen)
 
-	testBoard.ApplyMove(CreateCapture(SQUARE_H7, SQUARE_H4))
+	testBoard.ApplyMove(CreateMove(SQUARE_H7, SQUARE_H4))
 
 	assert.False(t, testBoard.IsInCheck(BLACK_OFFSET))
 }

--- a/hash.go
+++ b/hash.go
@@ -82,10 +82,10 @@ func (boardState *BoardState) CreateHashKey(info *HashInfo) uint64 {
 
 // To be applied after a move has been made, to incrementally update the hash key.
 // For use in search
-func (boardState *BoardState) UpdateHashApplyMove(key uint64, oldBoardInfo BoardInfo, move Move) uint64 {
+func (boardState *BoardState) UpdateHashApplyMove(key uint64, oldBoardInfo BoardInfo, move Move, isCapture bool) uint64 {
 	info := boardState.hashInfo
 
-	if move.IsCapture() {
+	if isCapture {
 		capturePiece := boardState.captureStack.Peek()
 
 		if move.IsEnPassantCapture() {
@@ -159,9 +159,9 @@ func (boardState *BoardState) UpdateHashApplyMove(key uint64, oldBoardInfo Board
 // UpdateHashUnapplyMove gives a new hash key as a result of unapplying a move.
 // It should be called _after_ the move has been unprocessed, and the oldBoardInfo
 // should be the board info prior to the move being unprocessed.
-func (boardState *BoardState) UpdateHashUnapplyMove(key uint64, oldBoardInfo BoardInfo, move Move) uint64 {
+func (boardState *BoardState) UpdateHashUnapplyMove(key uint64, oldBoardInfo BoardInfo, move Move, isCapture bool) uint64 {
 	info := boardState.hashInfo
-	if move.IsCapture() {
+	if isCapture {
 		// we've already put back the piece since this is done after move is unapplied
 		if move.IsEnPassantCapture() {
 			var pos uint8

--- a/move_generation.go
+++ b/move_generation.go
@@ -343,7 +343,6 @@ func generatePieceMoves(
 		oppositePiece := boardState.PieceAtSquare(move.to)
 		if oppositePiece != EMPTY_SQUARE {
 			if oppositePiece&0xF0 != p&0xF0 {
-				move.flags |= CAPTURE_MASK
 				listing.captures = append(listing.captures, move)
 			} else {
 				// same color, just skip it
@@ -410,7 +409,7 @@ func generatePawnMoves(
 		otherOccupancies = SetBitboard(otherOccupancies, boardState.boardInfo.enPassantTargetSquare)
 	}
 	pawnAttacks := boardState.moveBitboards.pawnAttacks[offset][sq]
-	captures := CreateCapturesFromBitboard(sq, pawnAttacks&otherOccupancies)
+	captures := CreateMovesFromBitboard(sq, pawnAttacks&otherOccupancies)
 
 	for _, capture := range captures {
 		var destRank = Rank(capture.to)
@@ -427,7 +426,7 @@ func generatePawnMoves(
 			listing.promotions = append(listing.promotions, capture)
 		} else {
 			if capture.to == boardState.boardInfo.enPassantTargetSquare {
-				capture.flags |= SPECIAL1_MASK
+				capture.flags |= SPECIAL1_MASK | CAPTURE_MASK
 			}
 			listing.captures = append(listing.captures, capture)
 		}

--- a/move_generation_test.go
+++ b/move_generation_test.go
@@ -21,11 +21,11 @@ func filterMovesFrom(moves []Move, from uint8) []Move {
 	return filteredMoves
 }
 
-func filterCaptures(moves []Move) []Move {
+func filterCaptures(moves []Move, boardState *BoardState) []Move {
 	var captures []Move
 
 	for _, move := range moves {
-		if move.IsCapture() {
+		if boardState.board[move.to] != EMPTY_SQUARE || move.IsEnPassantCapture() {
 			captures = append(captures, move)
 		}
 	}
@@ -42,7 +42,7 @@ func TestMoveGenerationWorks(t *testing.T) {
 	moves := GenerateMoves(&testBoard)
 
 	movesFromKing := filterMovesFrom(moves, SQUARE_A2)
-	numCaptures := len(filterCaptures(moves))
+	numCaptures := len(filterCaptures(moves, &testBoard))
 
 	assert.Equal(t, 4, len(movesFromKing))
 	assert.Equal(t, 1, numCaptures)
@@ -57,7 +57,7 @@ func TestMoveGenerationFromRook(t *testing.T) {
 
 	moves := GenerateMoves(&testBoard)
 	movesFromRook := filterMovesFrom(moves, SQUARE_A2)
-	numCaptures := len(filterCaptures(moves))
+	numCaptures := len(filterCaptures(moves, &testBoard))
 
 	// total 8 moves: 2 captures, A3 (1 step move), B2, C2, D2, E2, F2
 	assert.Equal(t, 8, len(movesFromRook))
@@ -141,7 +141,7 @@ func TestEnPassantCaptureFromPawn(t *testing.T) {
 	moves := GenerateMoves(&testBoard)
 
 	assert.Equal(t, 2, len(moves))
-	assert.Equal(t, 1, len(filterCaptures(moves)))
+	assert.Equal(t, 1, len(filterCaptures(moves, &testBoard)))
 }
 
 func TestCreateMoveBitboardsPawnAsserts(t *testing.T) {

--- a/move_test.go
+++ b/move_test.go
@@ -14,19 +14,10 @@ func TestCreateMove(t *testing.T) {
 	assert.Equal(t, Move{from: 31, to: 51}, m)
 }
 
-func TestCreateCapture(t *testing.T) {
-	var m = CreateCapture(31, 51)
-
-	assert.Equal(t, Move{from: 31, to: 51, flags: 0x80}, m)
-	assert.True(t, m.IsCapture())
-	assert.False(t, m.IsEnPassantCapture())
-}
-
 func TestCreateCapturePromotion(t *testing.T) {
 	var m = CreatePromotionCapture(SQUARE_A7, SQUARE_B8, QUEEN_MASK)
 
-	assert.Equal(t, Move{from: SQUARE_A7, to: SQUARE_B8, flags: 0xC5}, m)
-	assert.True(t, m.IsCapture())
+	assert.Equal(t, Move{from: SQUARE_A7, to: SQUARE_B8, flags: 0x45}, m)
 	assert.True(t, m.IsPromotion())
 }
 
@@ -34,7 +25,6 @@ func TestCreateEnPassantCapture(t *testing.T) {
 	var m = CreateEnPassantCapture(31, 51)
 
 	assert.Equal(t, Move{from: 31, to: 51, flags: 0xA0}, m)
-	assert.True(t, m.IsCapture())
 	assert.True(t, m.IsEnPassantCapture())
 }
 
@@ -44,24 +34,28 @@ func TestCreateCastle(t *testing.T) {
 }
 
 func TestMoveToString(t *testing.T) {
-	assert.Equal(t, "a2xa4", MoveToString(CreateCapture(SQUARE_A2, SQUARE_A4)))
-	assert.Equal(t, "a2xa4", MoveToString(CreateEnPassantCapture(SQUARE_A2, SQUARE_A4)))
-	assert.Equal(t, "a2-a4", MoveToString(CreateMove(SQUARE_A2, SQUARE_A4)))
-	assert.Equal(t, "O-O", MoveToString(CreateKingsideCastle(25, 27)))
-	assert.Equal(t, "O-O-O", MoveToString(CreateQueensideCastle(25, 23)))
+	boardState := CreateEmptyBoardState()
+
+	assert.Equal(t, "a2-a4", MoveToString(CreateMove(SQUARE_A2, SQUARE_A4), &boardState))
+	boardState.board[SQUARE_A4] = WHITE_MASK | PAWN_MASK
+	assert.Equal(t, "a2xa4", MoveToString(CreateMove(SQUARE_A2, SQUARE_A4), &boardState))
+	assert.Equal(t, "a2xa4", MoveToString(CreateEnPassantCapture(SQUARE_A2, SQUARE_A4), &boardState))
+	assert.Equal(t, "O-O", MoveToString(CreateKingsideCastle(25, 27), &boardState))
+	assert.Equal(t, "O-O-O", MoveToString(CreateQueensideCastle(25, 23), &boardState))
 }
 
 func TestMoveToPrettyString(t *testing.T) {
 	var boardState BoardState = CreateEmptyBoardState()
 
 	boardState.SetPieceAtSquare(SQUARE_A2, WHITE_MASK|PAWN_MASK)
+	boardState.SetPieceAtSquare(SQUARE_B4, BLACK_MASK|PAWN_MASK)
 	boardState.SetPieceAtSquare(SQUARE_F5, WHITE_MASK|KNIGHT_MASK)
 	boardState.SetPieceAtSquare(SQUARE_G7, BLACK_MASK|ROOK_MASK)
 
-	assert.Equal(t, "axb4", MoveToPrettyString(CreateCapture(SQUARE_A2, SQUARE_B4), &boardState))
+	assert.Equal(t, "axb4", MoveToPrettyString(CreateMove(SQUARE_A2, SQUARE_B4), &boardState))
 	assert.Equal(t, "axb4", MoveToPrettyString(CreateEnPassantCapture(SQUARE_A2, SQUARE_B4), &boardState))
 	assert.Equal(t, "a4", MoveToPrettyString(CreateMove(SQUARE_A2, SQUARE_A4), &boardState))
-	assert.Equal(t, "Nxg7", MoveToPrettyString(CreateCapture(SQUARE_F5, SQUARE_G7), &boardState))
+	assert.Equal(t, "Nxg7", MoveToPrettyString(CreateMove(SQUARE_F5, SQUARE_G7), &boardState))
 }
 
 func TestParsePrettyMoveFromInitial(t *testing.T) {

--- a/perft.go
+++ b/perft.go
@@ -131,27 +131,30 @@ func Perft(boardState *BoardState, depth uint, options PerftOptions, hint MoveSi
 			case BLACK_OFFSET:
 				otherOffset = WHITE_OFFSET
 			}
-			if !boardState.IsInCheck(otherOffset) {
-				wasValid = true
-
-				if move.IsCapture() {
-					captures++
-				}
-				if move.IsKingsideCastle() || move.IsQueensideCastle() {
-					castles++
-				}
-				if move.IsPromotion() {
-					promotions++
-				}
-
-				info := Perft(boardState, depth-1, options, hint)
-				if options.divide && depth == options.depth {
-					fmt.Printf("%s %d\n", MoveToString(move), info.nodes)
-				}
-				addPerftInfo(&perftInfo, info)
+			if boardState.IsInCheck(otherOffset) {
+				boardState.UnapplyMove(move)
+				continue
 			}
 
+			wasValid = true
+			if boardState.wasCapture[boardState.moveIndex-1] {
+				captures++
+			}
+			if move.IsKingsideCastle() || move.IsQueensideCastle() {
+				castles++
+			}
+			if move.IsPromotion() {
+				promotions++
+			}
+
+			info := Perft(boardState, depth-1, options, hint)
 			boardState.UnapplyMove(move)
+
+			if options.divide && depth == options.depth {
+				fmt.Printf("%s %d\n", MoveToString(move, boardState), info.nodes)
+			}
+			addPerftInfo(&perftInfo, info)
+
 			if depth == 1 && options.perftPrintMoves {
 				if wasValid {
 					fmt.Println(MoveToPrettyString(move, boardState))
@@ -190,7 +193,7 @@ func testMoveLegality(boardState *BoardState, move Move) {
 	if !legal {
 		fmt.Println(err)
 		fmt.Println(boardState.ToString())
-		fmt.Println(MoveToString(move))
+		fmt.Println(MoveToString(move, boardState))
 		panic("Illegal move")
 	}
 }

--- a/search.go
+++ b/search.go
@@ -183,7 +183,7 @@ FindBestMove:
 					strings.Contains(result.pv, searchConfig.debugMoves) ||
 					searchConfig.debugMoves == "*") {
 					fmt.Printf("[%d; %s] value=%d, result=%s, pv=%s\n", depth,
-						MoveToString(move), result.value, SearchResultToString(result), result.pv)
+						MoveToString(move, boardState), result.value, SearchResultToString(result), result.pv)
 				}
 
 				alpha = Max(alpha, result.value)
@@ -296,8 +296,9 @@ func getNoLegalMoveResult(boardState *BoardState, currentDepth uint, searchConfi
 }
 
 func SearchResultToString(result SearchResult) string {
-	return fmt.Sprintf("%s (value=%s, depth=%d, stats=%s, pv=%s)",
-		MoveToString(result.move),
+	return fmt.Sprintf("%s-%s (value=%s, depth=%d, stats=%s, pv=%s)",
+		SquareToAlgebraicString(result.move.from),
+		SquareToAlgebraicString(result.move.to),
 		SearchValueToString(result),
 		result.depth,
 		SearchStatsToString(result.stats),

--- a/search_test.go
+++ b/search_test.go
@@ -53,8 +53,7 @@ func TestSearchAvoidMateInOne(t *testing.T) {
 
 	result := Search(&boardState, 1)
 
-	assert.True(t, result.move.IsCapture())
-	assert.Equal(t, Move{from: SQUARE_F5, to: SQUARE_D5, flags: CAPTURE_MASK}, result.move)
+	assert.Equal(t, Move{from: SQUARE_F5, to: SQUARE_D5}, result.move)
 }
 
 func TestSearchWhiteForcesPawnPromotion(t *testing.T) {

--- a/tactics.go
+++ b/tactics.go
@@ -51,7 +51,6 @@ func RunTacticsFile(epdFile string, variation string, options TacticsOptions) (b
 		if moveToCheck != "" {
 			var moveMatches bool
 			if strings.Contains(moveToCheck, prettyMove) ||
-				strings.Contains(moveToCheck, MoveToString(result.move)) ||
 				strings.Contains(moveToCheck, SquareToAlgebraicString(result.move.from)+SquareToAlgebraicString(result.move.to)) {
 				moveMatches = true
 			}

--- a/xboard_test.go
+++ b/xboard_test.go
@@ -142,7 +142,7 @@ func TestParseXboardMoveCapture(t *testing.T) {
 	move, err := ParseXboardMove("a1a2", &boardState)
 
 	assert.Nil(t, err)
-	assert.Equal(t, Move{from: SQUARE_A1, to: SQUARE_A2, flags: CAPTURE_MASK}, move)
+	assert.Equal(t, Move{from: SQUARE_A1, to: SQUARE_A2}, move)
 }
 
 func TestParseXboardMovePromotion(t *testing.T) {
@@ -174,7 +174,7 @@ func TestParseXboardMovePromotionCapture(t *testing.T) {
 	assert.True(t, move.IsPromotion())
 	assert.Equal(t, move.from, SQUARE_H7)
 	assert.Equal(t, move.to, SQUARE_G8)
-	assert.Equal(t, move.flags, PROMOTION_MASK|CAPTURE_MASK|ROOK_MASK)
+	assert.Equal(t, move.flags, PROMOTION_MASK|ROOK_MASK)
 }
 
 func TestParseXboardMoveKingsideCastle(t *testing.T) {
@@ -214,7 +214,7 @@ func TestParseXboardMoveEnPassantCapture(t *testing.T) {
 	move, err := ParseXboardMove("e5d6", &boardState)
 
 	assert.Nil(t, err)
-	assert.True(t, move.IsCapture())
+	assert.True(t, move.IsEnPassantCapture())
 	assert.Equal(t, SQUARE_E5, move.from)
 	assert.Equal(t, SQUARE_D6, move.to)
 }


### PR DESCRIPTION
The idea here is to allow us to just use the precomputed moves from the in-memory slices rather than having to copy these around during search.