### PR TITLE
Fix xboard issues

### DIFF
--- a/board.go
+++ b/board.go
@@ -224,6 +224,8 @@ type RepetitionInfo struct {
 	pawnMoveOrCapture [MAX_MOVES]bool
 }
 
+var shouldAbort = false
+
 type BoardState struct {
 	board         []byte
 	bitboards     Bitboards
@@ -248,9 +250,6 @@ type BoardState struct {
 	hashInfo *HashInfo
 	// Transposition table
 	transpositionTable map[uint64]*TranspositionEntry
-
-	// Argument to abort search during tactics module
-	shouldAbort bool
 
 	repetitionInfo RepetitionInfo
 }

--- a/search.go
+++ b/search.go
@@ -145,7 +145,7 @@ func searchAlphaBeta(
 		}
 	}
 
-	if boardState.shouldAbort {
+	if shouldAbort {
 		score := getLeafResult(boardState, searchStats)
 		StoreTranspositionTable(boardState, Move{}, score, TT_EXACT, depthLeft)
 
@@ -311,7 +311,7 @@ func searchQuiescent(
 		bestScore = score
 		alpha = score
 	}
-	if boardState.shouldAbort {
+	if shouldAbort {
 		return score
 	}
 

--- a/tactics.go
+++ b/tactics.go
@@ -123,8 +123,6 @@ func RunTacticsFen(fen string, variation string, options TacticsOptions) (string
 		return "", result, nil
 	}
 
-	boardState.shouldAbort = true
-
 	if options.tacticsHashVariation != "" {
 		// "Wiggle room" to allow search to abort
 		time.Sleep(time.Duration(200) * time.Millisecond)

--- a/xboard.go
+++ b/xboard.go
@@ -154,26 +154,30 @@ func thinkAndChooseMove(
 	thinkingChan chan ThinkingOutput,
 ) {
 	shouldAbort = false
+	// NOTE - There seems to be a bug in the TT where the wrong move is being returned
+	// For now clear out the TT before starting to think
+	generateTranspositionTable(boardState)
+
 	searchQuit := make(chan bool)
 	resultCh := make(chan SearchResult)
 
 	go func() {
 		var i uint = 1
-		var res SearchResult
+		// var res SearchResult
 
 		for {
 			select {
-			case resultCh <- res:
-				// result sent
 			case <-searchQuit:
 				close(resultCh)
 				close(searchQuit)
 				return
 			default:
 				// TODO: having to copy the board state indicates a bug somewhere
-				logger.Println(fmt.Printf("Searching depth %d\n", i))
+				logger.Printf("Searching depth %d\n", i)
 				state := CopyBoardState(boardState)
-				res = SearchWithConfig(&state, uint(i), config)
+				result := SearchWithConfig(&state, uint(i), config)
+				logger.Printf("Depth %d: %s\n", i, result.String())
+				resultCh <- result
 				i = i + 1
 			}
 		}

--- a/xboard.go
+++ b/xboard.go
@@ -153,6 +153,7 @@ func thinkAndChooseMove(
 	ch chan SearchResult,
 	thinkingChan chan ThinkingOutput,
 ) {
+	shouldAbort = false
 	searchQuit := make(chan bool)
 	resultCh := make(chan SearchResult)
 
@@ -170,6 +171,7 @@ func thinkAndChooseMove(
 				return
 			default:
 				// TODO: having to copy the board state indicates a bug somewhere
+				logger.Println(fmt.Printf("Searching depth %d\n", i))
 				state := CopyBoardState(boardState)
 				res = SearchWithConfig(&state, uint(i), config)
 				i = i + 1
@@ -216,6 +218,7 @@ func thinkAndChooseMove(
 			}
 		}
 
+		shouldAbort = true
 		ch <- bestResult
 		close(ch)
 		close(thinkingChan)


### PR DESCRIPTION
Some hacky fixes to get it to abort search when told (concurrent hashmap issue with transposition table) and to stop making illegal no-op moves (a1a1).  Didn't fix the cause of the second issue yet.