### PR TITLE
Move gen: use slices instead of array refs

### DIFF
--- a/check_detection.go
+++ b/check_detection.go
@@ -97,7 +97,7 @@ func (boardState *BoardState) IsCheckmate() bool {
 	}
 
 	moves := make([]Move, 256)
-	end := GenerateMoves(boardState, &moves, 0)
+	end := GenerateMoves(boardState, moves[:], 0)
 	offset := boardState.sideToMove
 
 	for _, move := range moves[0:end] {

--- a/check_detection_test.go
+++ b/check_detection_test.go
@@ -91,7 +91,7 @@ func TestFilterChecks(t *testing.T) {
 	testBoard.SetPieceAtSquare(SQUARE_H2, WHITE_MASK|QUEEN_MASK)
 
 	moves := make([]Move, 64)
-	end := GenerateMoves(&testBoard, &moves, 0)
+	end := GenerateMoves(&testBoard, moves[:], 0)
 	checks := testBoard.FilterChecks(moves[0:end])
 
 	assertMovePresent(t, checks, SQUARE_H2, SQUARE_H3)

--- a/magic.go
+++ b/magic.go
@@ -399,7 +399,7 @@ func GenerateRookSlidingMoves(
 		key := hashKey(occupancy, magic)
 		attackBoard := RookMoveBoard(sq, occupancy)
 		moves := make([]Move, 64)
-		end := CreateMovesFromBitboard(sq, attackBoard, &moves, 0, 0)
+		end := CreateMovesFromBitboard(sq, attackBoard, moves[:], 0, 0)
 		attacks[key] = SquareAttacks{
 			board: attackBoard,
 			moves: moves[0:end],
@@ -417,7 +417,7 @@ func GenerateBishopSlidingMoves(
 		key := hashKey(occupancy, magic)
 		attackBoard := BishopMoveBoard(sq, occupancy)
 		moves := make([]Move, 64)
-		end := CreateMovesFromBitboard(sq, attackBoard, &moves, 0, 0)
+		end := CreateMovesFromBitboard(sq, attackBoard, moves[:], 0, 0)
 		attacks[key] = SquareAttacks{
 			board: attackBoard,
 			moves: moves[0:end],

--- a/move.go
+++ b/move.go
@@ -240,7 +240,7 @@ func ParsePrettyMove(moveStr string, boardState *BoardState) (Move, error) {
 	}
 
 	moves := make([]Move, 256)
-	end := GenerateMoves(boardState, &moves, 0)
+	end := GenerateMoves(boardState, moves[:], 0)
 	for _, candidateMove := range moves[0:end] {
 		p := boardState.PieceAtSquare(candidateMove.from) & 0x0F
 		if (candidateMove.to == toSquare || isKingsideCastle || isQueensideCastle) &&

--- a/move_generation_test.go
+++ b/move_generation_test.go
@@ -35,7 +35,7 @@ func filterCaptures(moves []Move, boardState *BoardState) []Move {
 
 func generateMovesFromBoard(boardState *BoardState) []Move {
 	moves := make([]Move, 64)
-	end := GenerateMoves(boardState, &moves, 0)
+	end := GenerateMoves(boardState, moves[:], 0)
 	return moves[:end]
 }
 
@@ -202,7 +202,7 @@ func TestCreateMovesFromBitboard(t *testing.T) {
 	bitboard = SetBitboard(bitboard, SQUARE_D4)
 
 	moves := make([]Move, 64)
-	end := CreateMovesFromBitboard(SQUARE_D3, bitboard, &moves, 0, 0)
+	end := CreateMovesFromBitboard(SQUARE_D3, bitboard, moves[:], 0, 0)
 	assert.Equal(t, 3, end)
 	assertMovePresent(t, moves[0:end], SQUARE_D3, SQUARE_A5)
 	assertMovePresent(t, moves[0:end], SQUARE_D3, SQUARE_B3)
@@ -218,7 +218,7 @@ func TestGenerateQuiescentMoves(t *testing.T) {
 
 	moves := make([]Move, 64)
 	moveScores := make([]int, len(moves))
-	end := GenerateQuiescentMoves(&testBoard, &moves, &moveScores, 0)
+	end := GenerateQuiescentMoves(&testBoard, moves[:], moveScores[:], 0)
 	assert.Equal(t, 3, end)
 
 	// verify ordering of captures

--- a/move_sort.go
+++ b/move_sort.go
@@ -7,8 +7,8 @@ import (
 // from https://golang.org/pkg/container/heap/
 
 type MoveSort struct {
-	moves      *[]Move
-	moveScores *[]int
+	moves      []Move
+	moveScores []int
 	startIndex int
 	endIndex   int
 }
@@ -20,26 +20,26 @@ func (pq MoveSort) Len() int {
 func (pq MoveSort) Less(i, j int) bool {
 	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
 	idx := pq.startIndex
-	return (*pq.moveScores)[idx+i] > (*pq.moveScores)[idx+j]
+	return pq.moveScores[idx+i] > pq.moveScores[idx+j]
 }
 
 func (pq MoveSort) Swap(i, j int) {
 	idx := pq.startIndex
-	(*pq.moves)[idx+i], (*pq.moves)[idx+j] = (*pq.moves)[idx+j], (*pq.moves)[idx+i]
-	(*pq.moveScores)[idx+i], (*pq.moveScores)[idx+j] = (*pq.moveScores)[idx+j], (*pq.moveScores)[idx+i]
+	pq.moves[idx+i], pq.moves[idx+j] = pq.moves[idx+j], pq.moves[idx+i]
+	pq.moveScores[idx+i], pq.moveScores[idx+j] = pq.moveScores[idx+j], pq.moveScores[idx+i]
 }
 
 func SortMoves(
 	boardState *BoardState,
 	moveInfo *SearchMoveInfo,
 	currentDepth uint,
-	moves *[]Move,
-	moveScores *[]int,
+	moves []Move,
+	moveScores []int,
 	start int,
 	end int,
 ) {
 	for i := start; i < end; i++ {
-		move := (*moves)[i]
+		move := moves[i]
 		var score int = MOVE_SCORE_NORMAL
 		toPiece := boardState.PieceAtSquare(move.to)
 		if move == moveInfo.killerMoves[currentDepth] {
@@ -56,21 +56,21 @@ func SortMoves(
 		} else {
 			// TODO - check detection
 		}
-		(*moveScores)[i] = score
+		moveScores[i] = score
 	}
 	moveSort := MoveSort{startIndex: start, endIndex: end, moves: moves, moveScores: moveScores}
 	sort.Sort(&moveSort)
 }
 
-func SortQuiescentMoves(boardState *BoardState, moves *[]Move, moveScores *[]int, start int, end int) {
+func SortQuiescentMoves(boardState *BoardState, moves []Move, moveScores []int, start int, end int) {
 	moveSort := MoveSort{startIndex: start, endIndex: end, moves: moves, moveScores: moveScores}
 
 	for i := start; i < end; i++ {
-		capture := (*moves)[i]
+		capture := moves[i]
 		fromPiece := boardState.PieceAtSquare(capture.from)
 		toPiece := boardState.PieceAtSquare(capture.to)
 		priority := mvvPriority[fromPiece&0x0F][toPiece&0x0F]
-		(*moveScores)[i] = priority
+		moveScores[i] = priority
 	}
 	sort.Sort(&moveSort)
 }

--- a/move_sort_test.go
+++ b/move_sort_test.go
@@ -17,8 +17,8 @@ func TestMoveSort(t *testing.T) {
 	captureQueue := MoveSort{
 		startIndex: 0,
 		endIndex:   len(moves),
-		moves:      &moves,
-		moveScores: &moveScores,
+		moves:      moves[:],
+		moveScores: moveScores[:],
 	}
 	sort.Sort(&captureQueue)
 

--- a/perft.go
+++ b/perft.go
@@ -53,7 +53,7 @@ func RunPerftJson(perftJsonFile string, options PerftOptions) (bool, error) {
 		start := time.Now()
 		moves := make([]Move, 13824)
 		var moveStart [64]int
-		perftResult := Perft(&board, spec.Depth, options, &moves, &moveStart)
+		perftResult := Perft(&board, spec.Depth, options, moves[:], moveStart[:])
 		elapsed := time.Since(start)
 		if perftResult.nodes != spec.Nodes {
 			fmt.Printf("NOT OK: %s (depth=%d, expected nodes=%d, actual nodes=%d; duration=%s)\n", spec.Fen, spec.Depth, spec.Nodes, perftResult.nodes, elapsed)
@@ -86,7 +86,7 @@ func RunPerft(fen string, variation string, depth uint, options PerftOptions) (b
 			start := time.Now()
 			moves := make([]Move, 13824)
 			var moveStart [64]int
-			result := Perft(&boardState, i, options, &moves, &moveStart)
+			result := Perft(&boardState, i, options, moves[:], moveStart[:])
 			fmt.Printf("%d\t%10d\t%s\n", i, result.nodes, time.Since(start))
 		} else {
 			fmt.Println(err)
@@ -96,7 +96,7 @@ func RunPerft(fen string, variation string, depth uint, options PerftOptions) (b
 	return true, nil
 }
 
-func Perft(boardState *BoardState, depth uint, options PerftOptions, moves *[]Move, moveStart *[64]int) PerftInfo {
+func Perft(boardState *BoardState, depth uint, options PerftOptions, moves []Move, moveStart []int) PerftInfo {
 	var perftInfo PerftInfo
 
 	if options.checks && boardState.IsInCheck(boardState.sideToMove) {
@@ -109,15 +109,15 @@ func Perft(boardState *BoardState, depth uint, options PerftOptions, moves *[]Mo
 	}
 
 	currentDepth := options.depth - depth
-	start := (*moveStart)[currentDepth]
+	start := moveStart[currentDepth]
 	end := GenerateMoves(boardState, moves, start)
-	(*moveStart)[currentDepth+1] = end
+	moveStart[currentDepth+1] = end
 	captures := uint(0)
 	castles := uint(0)
 	promotions := uint(0)
 
 	for i := start; i < end; i++ {
-		move := (*moves)[i]
+		move := moves[i]
 		var originalHashKey uint64
 		var originalPawnHashKey uint64
 		if options.sanityCheck {

--- a/search.go
+++ b/search.go
@@ -130,9 +130,9 @@ func SearchWithConfig(
 		alpha,
 		beta,
 		searchConfig,
-		&moves,
-		&scores,
-		&moveStart,
+		moves[:],
+		scores[:],
+		moveStart[:],
 	)
 
 	result := SearchResult{}
@@ -179,9 +179,9 @@ func searchAlphaBeta(
 	alpha int,
 	beta int,
 	searchConfig SearchConfig,
-	moves *[]Move,
-	moveScores *[]int,
-	moveStart *[64]int,
+	moves []Move,
+	moveScores []int,
+	moveStart []int,
 ) int {
 	var line Variation
 
@@ -254,9 +254,9 @@ func searchAlphaBeta(
 	var bestMove Move
 	currentAlpha := alpha
 
-	start := (*moveStart)[currentDepth]
+	start := moveStart[currentDepth]
 	var moveEnd int
-	(*moveStart)[currentDepth+1] = start
+	moveStart[currentDepth+1] = start
 
 	for i := 0; i <= 1; i++ {
 		var moveOrdering []Move
@@ -265,7 +265,7 @@ func searchAlphaBeta(
 		} else {
 			// TODO - don't want to do this, we should index
 			// Fix this by putting the hashMove onto the move list in this scenario
-			moveOrdering = (*moves)[start:moveEnd]
+			moveOrdering = moves[start:moveEnd]
 		}
 
 		for _, move := range moveOrdering {
@@ -347,7 +347,7 @@ func searchAlphaBeta(
 		if i == 0 {
 			// add the other moves now that we're done with hash move
 			moveEnd = GenerateMoves(boardState, moves, start)
-			(*moveStart)[currentDepth+1] = moveEnd
+			moveStart[currentDepth+1] = moveEnd
 			SortMoves(boardState, moveInfo, currentDepth, moves, moveScores, start, moveEnd)
 		}
 	}
@@ -385,9 +385,9 @@ func searchQuiescent(
 	alpha int,
 	beta int,
 	searchConfig SearchConfig,
-	moves *[]Move,
-	moveScores *[]int,
-	moveStart *[64]int,
+	moves []Move,
+	moveScores []int,
+	moveStart []int,
 ) int {
 	var line Variation
 	var bestMove Move
@@ -407,16 +407,16 @@ func searchQuiescent(
 		return score
 	}
 
-	start := (*moveStart)[currentDepth]
+	start := moveStart[currentDepth]
 	endAllMoves := GenerateQuiescentMoves(boardState, moves, moveScores, start)
 	endGoodMoves := boardState.FilterSEECaptures(moves, start, endAllMoves)
-	(*moveStart)[currentDepth+1] = endGoodMoves
+	moveStart[currentDepth+1] = endGoodMoves
 
 	searchStats.qcapturesfiltered += uint64(endAllMoves - endGoodMoves)
 	searchStats.qbranchnodes++
 
 	for i := start; i < endGoodMoves; i++ {
-		move := (*moves)[i]
+		move := moves[i]
 		ourOffset := boardState.sideToMove
 		boardState.ApplyMove(move)
 		if boardState.IsInCheck(ourOffset) {

--- a/static_exchange_eval.go
+++ b/static_exchange_eval.go
@@ -54,20 +54,20 @@ func StaticExchangeEvaluation(boardState *BoardState, destSq byte, fromPiece byt
 	return gain[0]
 }
 
-func (boardState *BoardState) FilterSEECaptures(moves *[]Move, start int, end int) int {
+func (boardState *BoardState) FilterSEECaptures(moves []Move, start int, end int) int {
 	for start < end {
-		capture := (*moves)[start]
+		capture := moves[start]
 		fromPiece := boardState.board[capture.from] & 0x0F
 		if fromPiece == PAWN_MASK {
 			start++
 		} else if boardState.board[capture.to] == EMPTY_SQUARE {
-			(*moves)[start] = (*moves)[start+1]
+			moves[start] = moves[start+1]
 			end--
 		} else if StaticExchangeEvaluation(boardState, capture.to, fromPiece, capture.from) > 0 {
 			start++
 		} else {
 			// this move is garbage
-			(*moves)[start] = (*moves)[start+1]
+			moves[start] = moves[start+1]
 			end--
 		}
 	}

--- a/static_exchange_eval_test.go
+++ b/static_exchange_eval_test.go
@@ -55,8 +55,8 @@ func TestStaticExchangeEvaluationGuardedCapture(t *testing.T) {
 		StaticExchangeEvaluation(&boardState, SQUARE_D8, ROOK_MASK, SQUARE_E8))
 
 	moves := make([]Move, 64)
-	end := GenerateMoves(&boardState, &moves, 0)
-	end = boardState.FilterSEECaptures(&moves, 0, end)
+	end := GenerateMoves(&boardState, moves[:], 0)
+	end = boardState.FilterSEECaptures(moves[:], 0, end)
 	assert.Equal(t, 0, end)
 }
 
@@ -82,7 +82,7 @@ func TestStaticExchangeEvaluationStackOverflowQuestion(t *testing.T) {
 	assert.Equal(t, -400, StaticExchangeEvaluation(&boardState, SQUARE_H7, ROOK_MASK, SQUARE_H1))
 
 	moves := make([]Move, 64)
-	end := GenerateMoves(&boardState, &moves, 0)
-	end = boardState.FilterSEECaptures(&moves, 0, end)
+	end := GenerateMoves(&boardState, moves[:], 0)
+	end = boardState.FilterSEECaptures(moves[:], 0, end)
 	assert.Equal(t, 0, end)
 }


### PR DESCRIPTION
Passing a slice doesn't copy it.  Passing an array *does*.  Is there no way to specify that you take a slice and you can't take an array?