### PR TITLE
Improve sort performance by removing heap allocation

### DIFF
--- a/move_sort.go
+++ b/move_sort.go
@@ -36,6 +36,8 @@ func (pq MoveSort) Swap(i, j int) {
 	pq.moveScores[idx+i], pq.moveScores[idx+j] = pq.moveScores[idx+j], pq.moveScores[idx+i]
 }
 
+var moveSort MoveSort
+
 func SortMoves(
 	boardState *BoardState,
 	moveInfo *SearchMoveInfo,
@@ -69,12 +71,19 @@ func SortMoves(
 		}
 		moveScores[i] = score
 	}
-	moveSort := MoveSort{startIndex: start, endIndex: end, moves: moves, moveScores: moveScores}
+
+	moveSort.startIndex = start
+	moveSort.endIndex = end
+	moveSort.moves = moves
+	moveSort.moveScores = moveScores
 	sort.Sort(&moveSort)
 }
 
 func SortQuiescentMoves(boardState *BoardState, moves []Move, moveScores []int, start int, end int) {
-	moveSort := MoveSort{startIndex: start, endIndex: end, moves: moves, moveScores: moveScores}
+	moveSort.startIndex = start
+	moveSort.endIndex = end
+	moveSort.moves = moves
+	moveSort.moveScores = moveScores
 
 	for i := start; i < end; i++ {
 		capture := moves[i]
@@ -93,11 +102,9 @@ func SortMovesFirstPly(
 	start int,
 	end int,
 ) {
-	moveSort := MoveSort{
-		startIndex: start,
-		endIndex:   end,
-		moves:      moves,
-		moveScores: moveInfo.firstPlyScores[start:end],
-	}
+	moveSort.startIndex = start
+	moveSort.endIndex = end
+	moveSort.moves = moves
+	moveSort.moveScores = moveInfo.firstPlyScores[start:end]
 	sort.Sort(&moveSort)
 }

--- a/move_sort.go
+++ b/move_sort.go
@@ -20,20 +20,20 @@ type MoveSort struct {
 	endIndex   int
 }
 
-func (pq MoveSort) Len() int {
-	return pq.endIndex - pq.startIndex
+func (s MoveSort) Len() int {
+	return s.endIndex - s.startIndex
 }
 
-func (pq MoveSort) Less(i, j int) bool {
+func (s MoveSort) Less(i, j int) bool {
 	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
-	idx := pq.startIndex
-	return pq.moveScores[idx+i] > pq.moveScores[idx+j]
+	idx := s.startIndex
+	return s.moveScores[idx+i] > s.moveScores[idx+j]
 }
 
-func (pq MoveSort) Swap(i, j int) {
-	idx := pq.startIndex
-	pq.moves[idx+i], pq.moves[idx+j] = pq.moves[idx+j], pq.moves[idx+i]
-	pq.moveScores[idx+i], pq.moveScores[idx+j] = pq.moveScores[idx+j], pq.moveScores[idx+i]
+func (s MoveSort) Swap(i, j int) {
+	idx := s.startIndex
+	s.moves[idx+i], s.moves[idx+j] = s.moves[idx+j], s.moves[idx+i]
+	s.moveScores[idx+i], s.moveScores[idx+j] = s.moveScores[idx+j], s.moveScores[idx+i]
 }
 
 var moveSort MoveSort


### PR DESCRIPTION
Wow, this was fun to find.  It looks like anything passed to sort.Sort is thought of as escaping to the heap - https://github.com/golang/go/issues/15451.

There's an easy fix for this which is to allocate the struct in global context; since everything is single-threaded no issues with this.  I looked a little bit at using sort.Slice(); we can't use this because we want to sort one array based on the other.  After the first swaps happen in the original array the moveScore array gets out of sync.