### PR TITLE
Transposition table: try to be smarter about heap allocation

### DIFF
--- a/board.go
+++ b/board.go
@@ -250,7 +250,7 @@ type BoardState struct {
 	// Zobrist hash indices
 	hashInfo *HashInfo
 	// Transposition table
-	transpositionTable map[uint64]*TranspositionEntry
+	transpositionTable map[uint64]uint64
 	pawnTable          map[uint64]*PawnTableEntry
 
 	repetitionInfo RepetitionInfo

--- a/constants.go
+++ b/constants.go
@@ -1,5 +1,7 @@
 package main
 
+import "math"
+
 const EMPTY_SQUARE byte = 0x00
 const PAWN_MASK byte = 0x01
 const KNIGHT_MASK byte = 0x02
@@ -94,6 +96,7 @@ const RANK_6 byte = 0x06
 const RANK_7 byte = 0x07
 const RANK_8 byte = 0x08
 
-const CHECKMATE_SCORE = 100000
+const CHECKMATE_SCORE = 30_000
 const CONTEMPT_SCORE = 200
-const INFINITY = 10000000
+const INFINITY = math.MaxInt16
+const INFINITY_NEGATIVE = math.MinInt16

--- a/constants.go
+++ b/constants.go
@@ -99,4 +99,3 @@ const RANK_8 byte = 0x08
 const CHECKMATE_SCORE = 30_000
 const CONTEMPT_SCORE = 200
 const INFINITY = math.MaxInt16
-const INFINITY_NEGATIVE = math.MinInt16

--- a/move.go
+++ b/move.go
@@ -104,6 +104,13 @@ func CreatePromotion(from uint8, to uint8, pieceMask uint8) Move {
 	return m
 }
 
+func MoveToDebugString(move Move) string {
+	return fmt.Sprintf("%s-%s (%d)",
+		SquareToAlgebraicString(move.from),
+		SquareToAlgebraicString(move.to),
+		move.flags)
+}
+
 func MoveToString(move Move, boardState *BoardState) string {
 	if move.flags&SPECIAL1_MASK == SPECIAL1_MASK && !move.IsCapture(boardState) {
 		if move.flags&SPECIAL2_MASK == SPECIAL2_MASK {

--- a/move_generation.go
+++ b/move_generation.go
@@ -33,7 +33,7 @@ type MoveBitboards struct {
 }
 
 // Lifted from Apep https://github.com/tildedave/apep-chess-engine/blob/master/src/movegen.cpp#L8
-var mvvPriority = [7][7]int{
+var mvvPriority = [7][7]int16{
 	{0, 0, 0, 0, 0, 0, 0},
 	{0, 6, 12, 18, 24, 30, 0}, // PAWN CAPTURES PRIORITY: PAWN, KNIGHT, BISHOP, ROOK, QUEEN
 	{0, 5, 11, 17, 23, 29, 0}, // KNIGHT CAPTURES PRIORITY: PAWN, KNIGHT, BISHOP, ROOK, QUEEN
@@ -242,7 +242,7 @@ func GenerateMoves(boardState *BoardState, moves []Move, start int) int {
 	return start
 }
 
-func GenerateQuiescentMoves(boardState *BoardState, moves []Move, moveScores []int, start int) int {
+func GenerateQuiescentMoves(boardState *BoardState, moves []Move, moveScores []int16, start int) int {
 	// for now only generate captures
 	originalStart := start
 	precomputedInfo := generatePrecomputedInfo(boardState)

--- a/move_generation_test.go
+++ b/move_generation_test.go
@@ -217,7 +217,7 @@ func TestGenerateQuiescentMoves(t *testing.T) {
 	testBoard.SetPieceAtSquare(SQUARE_A8, BLACK_MASK|QUEEN_MASK)
 
 	moves := make([]Move, 64)
-	moveScores := make([]int, len(moves))
+	moveScores := make([]int16, len(moves))
 	end := GenerateQuiescentMoves(&testBoard, moves[:], moveScores[:], 0)
 	assert.Equal(t, 3, end)
 

--- a/move_sort.go
+++ b/move_sort.go
@@ -15,7 +15,7 @@ const MOVE_SCORE_KILLER_MOVE2 = 450
 
 type MoveSort struct {
 	moves      []Move
-	moveScores []int
+	moveScores []int16
 	startIndex int
 	endIndex   int
 }
@@ -43,7 +43,7 @@ func SortMoves(
 	moveInfo *SearchMoveInfo,
 	currentDepth uint,
 	moves []Move,
-	moveScores []int,
+	moveScores []int16,
 	start int,
 	end int,
 ) {
@@ -51,7 +51,7 @@ func SortMoves(
 
 	for i := start; i < end; i++ {
 		move := moves[i]
-		var score int = MOVE_SCORE_NORMAL
+		var score int16 = MOVE_SCORE_NORMAL
 		toPiece := boardState.PieceAtSquare(move.to)
 		if move == moveInfo.killerMoves[currentDepth] {
 			score = MOVE_SCORE_KILLER_MOVE
@@ -79,7 +79,7 @@ func SortMoves(
 	sort.Sort(&moveSort)
 }
 
-func SortQuiescentMoves(boardState *BoardState, moves []Move, moveScores []int, start int, end int) {
+func SortQuiescentMoves(boardState *BoardState, moves []Move, moveScores []int16, start int, end int) {
 	moveSort.startIndex = start
 	moveSort.endIndex = end
 	moveSort.moves = moves

--- a/move_sort_test.go
+++ b/move_sort_test.go
@@ -12,7 +12,7 @@ func TestMoveSort(t *testing.T) {
 	move2 := CreateMove(SQUARE_A8, SQUARE_A3)
 	move3 := CreateMove(SQUARE_A8, SQUARE_A1)
 	moves := []Move{move1, move2, move3}
-	moveScores := []int{21, 3, 27}
+	moveScores := []int16{21, 3, 27}
 
 	captureQueue := MoveSort{
 		startIndex: 0,

--- a/search.go
+++ b/search.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -107,7 +108,7 @@ func SearchWithConfig(
 	var moveStart [64]int
 	score := searchAlphaBeta(boardState, stats, moveInfo,
 		thinkingChan,
-		int(depth),
+		int8(depth),
 		0,
 		alpha,
 		beta,
@@ -161,7 +162,7 @@ func searchAlphaBeta(
 	searchStats *SearchStats,
 	moveInfo *SearchMoveInfo,
 	thinkingChan chan ThinkingOutput,
-	depthLeft int,
+	depthLeft int8,
 	currentDepth uint,
 	alpha int,
 	beta int,
@@ -261,7 +262,7 @@ func searchAlphaBeta(
 			// null move logic here
 			boardState.ApplyNullMove()
 
-			var R int
+			var R int8
 			if boardState.bitboards.piece[QUEEN_MASK] != 0 || boardState.bitboards.piece[ROOK_MASK] != 0 {
 				R = 3
 			} else {
@@ -322,7 +323,7 @@ func searchAlphaBeta(
 			}
 			searchConfig.isDebug = false
 
-			D := 0
+			var D int8 = 0
 			if IsPawnNearPromotion(boardState, move) {
 				D = 1
 			}
@@ -437,7 +438,7 @@ func searchQuiescent(
 	boardState *BoardState,
 	searchStats *SearchStats,
 	// depthLeft will always be negative
-	depthLeft int,
+	depthLeft int8,
 	currentDepth uint,
 	alpha int,
 	beta int,
@@ -605,7 +606,7 @@ func sendToThinkingChannel(
 	thinkingChan chan ThinkingOutput,
 	searchConfig SearchConfig,
 	score int,
-	depthLeft int,
+	depthLeft int8,
 ) {
 	boardState.ApplyMove(move)
 	pvMoves, _ := extractPV(boardState)
@@ -644,7 +645,7 @@ func extractPV(boardState *BoardState) ([]Move, bool) {
 	isDraw := false
 	pvMoves := make([]Move, 0)
 	e := ProbeTranspositionTable(boardState)
-	lastDepth := INFINITY
+	var lastDepth int8 = math.MaxInt8
 	for e != nil && e.depth <= lastDepth {
 		move := e.move
 		if _, err := boardState.IsMoveLegal(move); err != nil {

--- a/search.go
+++ b/search.go
@@ -315,11 +315,9 @@ func searchAlphaBeta(
 			hasLegalMove = true
 			searchConfig.move = move
 			var nodesStarting uint64
-			var hashKey uint64
 
 			if debugMode {
 				nodesStarting = searchStats.Nodes()
-				hashKey = boardState.hashKey
 			}
 			searchConfig.isDebug = false
 
@@ -350,9 +348,9 @@ func searchAlphaBeta(
 			if debugMode {
 				pv, _ := extractPV(boardState)
 				str := MoveArrayToXboardString(pv)
-				entry := boardState.transpositionTable[hashKey]
+				entry := ProbeTranspositionTable(boardState)
 				var entryType string
-				if entry != nil {
+				if entry == nil {
 					entryType = EntryTypeToString(entry.entryType)
 				}
 				fmt.Printf("[%d; %s] value=%d (alpha=%d, beta=%d, bestScore=%d) nodes=%d pv=%s result=%s\n",

--- a/search.go
+++ b/search.go
@@ -94,7 +94,7 @@ func SearchWithConfig(
 ) SearchResult {
 	startTime := time.Now()
 
-	alpha := INFINITY_NEGATIVE
+	alpha := -INFINITY
 	beta := INFINITY
 	searchConfig := SearchConfig{
 		isDebug:       config.isDebug,
@@ -234,7 +234,7 @@ func searchAlphaBeta(
 	// 4 = moves
 
 	hasLegalMove := false
-	var bestScore int16 = INFINITY_NEGATIVE
+	var bestScore int16 = -INFINITY + 1
 	var bestMove Move
 	currentAlpha := alpha
 
@@ -446,7 +446,7 @@ func searchQuiescent(
 	moveStart []int,
 ) int16 {
 	// var bestMove Move
-	var bestScore int16 = INFINITY_NEGATIVE
+	var bestScore int16 = -INFINITY + 1
 
 	// Evaluate the board to see what the position is without making any quiescent moves.
 	score := getLeafResult(boardState, searchStats)

--- a/search.go
+++ b/search.go
@@ -420,7 +420,7 @@ func searchAlphaBeta(
 		return score
 	}
 
-	var ttEntryType int
+	var ttEntryType uint8
 	if currentAlpha == alpha {
 		// never raised alpha
 		ttEntryType = TT_FAIL_LOW

--- a/search.go
+++ b/search.go
@@ -176,7 +176,7 @@ func searchAlphaBeta(
 
 	isDebug := searchConfig.isDebug
 
-	if entry := ProbeTranspositionTable(boardState); entry != nil {
+	if hasEntry, entry := ProbeTranspositionTable(boardState); hasEntry {
 		if currentDepth > 0 {
 			if entry.depth >= depthLeft {
 				switch entry.entryType {
@@ -348,9 +348,9 @@ func searchAlphaBeta(
 			if debugMode {
 				pv, _ := extractPV(boardState)
 				str := MoveArrayToXboardString(pv)
-				entry := ProbeTranspositionTable(boardState)
+				hasEntry, entry := ProbeTranspositionTable(boardState)
 				var entryType string
-				if entry == nil {
+				if hasEntry {
 					entryType = EntryTypeToString(entry.entryType)
 				}
 				fmt.Printf("[%d; %s] value=%d (alpha=%d, beta=%d, bestScore=%d) nodes=%d pv=%s result=%s\n",
@@ -642,9 +642,9 @@ func sendToThinkingChannel(
 func extractPV(boardState *BoardState) ([]Move, bool) {
 	isDraw := false
 	pvMoves := make([]Move, 0)
-	e := ProbeTranspositionTable(boardState)
+	hasEntry, e := ProbeTranspositionTable(boardState)
 	var lastDepth int8 = math.MaxInt8
-	for e != nil && e.depth <= lastDepth {
+	for hasEntry && e.depth <= lastDepth {
 		move := e.move
 		if _, err := boardState.IsMoveLegal(move); err != nil {
 			break
@@ -660,7 +660,7 @@ func extractPV(boardState *BoardState) ([]Move, bool) {
 			break
 		}
 		lastDepth = e.depth
-		e = ProbeTranspositionTable(boardState)
+		hasEntry, e = ProbeTranspositionTable(boardState)
 	}
 	for j := len(pvMoves) - 1; j >= 0; j-- {
 		move := pvMoves[j]

--- a/tactics.go
+++ b/tactics.go
@@ -144,12 +144,12 @@ func RunTacticsFen(fen string, variation string, options TacticsOptions) (string
 			return "", SearchResult{}, err
 		}
 
-		e := ProbeTranspositionTable(&boardState)
-		fmt.Printf("%s - %s\n", boardState.ToString(), e)
-		for i := 0; i < len(moveList) && e != nil; i++ {
+		hasEntry, e := ProbeTranspositionTable(&boardState)
+		fmt.Printf("%s - %s\n", boardState.ToString(), e.String())
+		for i := 0; i < len(moveList) && hasEntry; i++ {
 			boardState.ApplyMove(moveList[i])
-			e = ProbeTranspositionTable(&boardState)
-			fmt.Printf("%s - %s\n", boardState.ToString(), e)
+			hasEntry, e = ProbeTranspositionTable(&boardState)
+			fmt.Printf("%s - %s\n", boardState.ToString(), e.String())
 		}
 
 		for i := len(moveList) - 1; i >= 0; i-- {

--- a/transpositiontable.go
+++ b/transpositiontable.go
@@ -78,8 +78,8 @@ func StoreTranspositionTable(boardState *BoardState, move Move, score int16, ent
 	entry |= uint64(move.from) << (64 - 8)
 	entry |= uint64(move.to) << (64 - 16)
 	entry |= uint64(move.flags) << (64 - 24)
-	entry |= uint64(depth) << (64 - 32)
+	entry |= (uint64(depth) & 0xFF) << (64 - 32)
 	entry |= uint64(entryType) << (64 - 40)
-	entry |= uint64(score)
+	entry |= uint64(score) & 0xFFFFFF
 	boardState.transpositionTable[boardState.hashKey] = entry
 }

--- a/transpositiontable.go
+++ b/transpositiontable.go
@@ -7,8 +7,10 @@ import (
 type TranspositionEntry struct {
 	move      Move
 	depth     int8
-	score     int
-	entryType uint8 // technically this could just be 1-2 bits.
+	score     int16
+	entryType uint8
+	// technically this could just be 1-2 bits, we might want to give the
+	// other bytes to the score.
 }
 
 const TT_INITIAL_SIZE = 1048576
@@ -57,7 +59,7 @@ func (entry *TranspositionEntry) String() string {
 	return fmt.Sprintf("{score=%d, depth=%d, type=%s}", entry.score, entry.depth, entryTypeAsString)
 }
 
-func StoreTranspositionTable(boardState *BoardState, move Move, score int, entryType uint8, depth int8) {
+func StoreTranspositionTable(boardState *BoardState, move Move, score int16, entryType uint8, depth int8) {
 	// Try to avoid a new heap allocation if we already have something at this hash key.
 	var entry *TranspositionEntry
 	if boardState.transpositionTable[boardState.hashKey] != nil {

--- a/transpositiontable.go
+++ b/transpositiontable.go
@@ -6,7 +6,7 @@ import (
 
 type TranspositionEntry struct {
 	move        Move
-	depth       int
+	depth       int8
 	score       int
 	entryType   int
 	searchPhase int
@@ -58,7 +58,7 @@ func (entry *TranspositionEntry) String() string {
 	return fmt.Sprintf("{score=%d, depth=%d, type=%s}", entry.score, entry.depth, entryTypeAsString)
 }
 
-func StoreTranspositionTable(boardState *BoardState, move Move, score int, entryType int, depth int) {
+func StoreTranspositionTable(boardState *BoardState, move Move, score int, entryType int, depth int8) {
 	// Try to avoid a new heap allocation if we already have something at this hash key.
 	var entry *TranspositionEntry
 	if boardState.transpositionTable[boardState.hashKey] != nil {

--- a/transpositiontable.go
+++ b/transpositiontable.go
@@ -5,12 +5,14 @@ import (
 )
 
 type TranspositionEntry struct {
-	move      Move
-	depth     int8
-	score     int16
-	entryType uint8
+	move  Move
+	depth int8
 	// technically this could just be 1-2 bits, we might want to give the
 	// other bytes to the score.
+	entryType uint8
+	// We have 8 extra bytes at the end, we just pad them on the front of the
+	// score.
+	score int16
 }
 
 const TT_INITIAL_SIZE = 1048576
@@ -22,15 +24,26 @@ const (
 	TT_EXACT     = iota
 )
 
-var hashArray map[uint64]*TranspositionEntry
+var hashArray map[uint64]int
 
 func generateTranspositionTable(boardState *BoardState) {
-	boardState.transpositionTable = make(map[uint64]*TranspositionEntry, TT_INITIAL_SIZE)
+	boardState.transpositionTable = make(map[uint64]uint64, TT_INITIAL_SIZE)
 	boardState.pawnTable = make(map[uint64]*PawnTableEntry, PAWN_ENTRY_TABLE_INITIAL_SIZE)
 }
 
 func ProbeTranspositionTable(boardState *BoardState) *TranspositionEntry {
-	return boardState.transpositionTable[boardState.hashKey]
+	t := TranspositionEntry{}
+	entry := boardState.transpositionTable[boardState.hashKey]
+	if entry == 0 {
+		return nil
+	}
+	t.move.from = uint8((entry & (0xFF << (64 - 8))) >> (64 - 8))
+	t.move.to = uint8((entry & (0xFF << (64 - 16))) >> (64 - 16))
+	t.move.flags = uint8((entry & (0xFF << (64 - 24))) >> (64 - 24))
+	t.depth = int8((entry & (0xFF << (64 - 32))) >> (64 - 32))
+	t.entryType = uint8((entry & (0xFF << (64 - 40))) >> (64 - 40))
+	t.score = int16(entry & 0xFFFFFF)
+	return &t
 }
 
 func EntryTypeToString(entryType uint8) string {
@@ -56,20 +69,17 @@ func (entry *TranspositionEntry) String() string {
 	case TT_EXACT:
 		entryTypeAsString = "exact"
 	}
-	return fmt.Sprintf("{score=%d, depth=%d, type=%s}", entry.score, entry.depth, entryTypeAsString)
+	return fmt.Sprintf("{move=%s score=%d, depth=%d, type=%s}",
+		MoveToDebugString(entry.move), entry.score, entry.depth, entryTypeAsString)
 }
 
 func StoreTranspositionTable(boardState *BoardState, move Move, score int16, entryType uint8, depth int8) {
-	// Try to avoid a new heap allocation if we already have something at this hash key.
-	var entry *TranspositionEntry
-	if boardState.transpositionTable[boardState.hashKey] != nil {
-		entry = boardState.transpositionTable[boardState.hashKey]
-	} else {
-		entry = &(TranspositionEntry{})
-	}
-	entry.score = score
-	entry.move = move
-	entry.entryType = entryType
-	entry.depth = depth
+	var entry uint64
+	entry |= uint64(move.from) << (64 - 8)
+	entry |= uint64(move.to) << (64 - 16)
+	entry |= uint64(move.flags) << (64 - 24)
+	entry |= uint64(depth) << (64 - 32)
+	entry |= uint64(entryType) << (64 - 40)
+	entry |= uint64(score)
 	boardState.transpositionTable[boardState.hashKey] = entry
 }

--- a/transpositiontable.go
+++ b/transpositiontable.go
@@ -5,11 +5,10 @@ import (
 )
 
 type TranspositionEntry struct {
-	move        Move
-	depth       int8
-	score       int
-	entryType   int
-	searchPhase int
+	move      Move
+	depth     int8
+	score     int
+	entryType uint8 // technically this could just be 1-2 bits.
 }
 
 const TT_INITIAL_SIZE = 1048576
@@ -32,7 +31,7 @@ func ProbeTranspositionTable(boardState *BoardState) *TranspositionEntry {
 	return boardState.transpositionTable[boardState.hashKey]
 }
 
-func EntryTypeToString(entryType int) string {
+func EntryTypeToString(entryType uint8) string {
 	switch entryType {
 	case TT_FAIL_HIGH:
 		return "TT_FAIL_HIGH"
@@ -58,7 +57,7 @@ func (entry *TranspositionEntry) String() string {
 	return fmt.Sprintf("{score=%d, depth=%d, type=%s}", entry.score, entry.depth, entryTypeAsString)
 }
 
-func StoreTranspositionTable(boardState *BoardState, move Move, score int, entryType int, depth int8) {
+func StoreTranspositionTable(boardState *BoardState, move Move, score int, entryType uint8, depth int8) {
 	// Try to avoid a new heap allocation if we already have something at this hash key.
 	var entry *TranspositionEntry
 	if boardState.transpositionTable[boardState.hashKey] != nil {

--- a/transpositiontable.go
+++ b/transpositiontable.go
@@ -31,11 +31,11 @@ func generateTranspositionTable(boardState *BoardState) {
 	boardState.pawnTable = make(map[uint64]*PawnTableEntry, PAWN_ENTRY_TABLE_INITIAL_SIZE)
 }
 
-func ProbeTranspositionTable(boardState *BoardState) *TranspositionEntry {
+func ProbeTranspositionTable(boardState *BoardState) (bool, TranspositionEntry) {
 	t := TranspositionEntry{}
 	entry := boardState.transpositionTable[boardState.hashKey]
 	if entry == 0 {
-		return nil
+		return false, TranspositionEntry{}
 	}
 	t.move.from = uint8((entry & (0xFF << (64 - 8))) >> (64 - 8))
 	t.move.to = uint8((entry & (0xFF << (64 - 16))) >> (64 - 16))
@@ -43,7 +43,7 @@ func ProbeTranspositionTable(boardState *BoardState) *TranspositionEntry {
 	t.depth = int8((entry & (0xFF << (64 - 32))) >> (64 - 32))
 	t.entryType = uint8((entry & (0xFF << (64 - 40))) >> (64 - 40))
 	t.score = int16(entry & 0xFFFFFF)
-	return &t
+	return true, t
 }
 
 func EntryTypeToString(entryType uint8) string {

--- a/transpositiontable.go
+++ b/transpositiontable.go
@@ -59,6 +59,16 @@ func (entry *TranspositionEntry) String() string {
 }
 
 func StoreTranspositionTable(boardState *BoardState, move Move, score int, entryType int, depth int) {
-	entry := TranspositionEntry{score: score, move: move, entryType: entryType, depth: depth}
-	boardState.transpositionTable[boardState.hashKey] = &entry
+	// Try to avoid a new heap allocation if we already have something at this hash key.
+	var entry *TranspositionEntry
+	if boardState.transpositionTable[boardState.hashKey] != nil {
+		entry = boardState.transpositionTable[boardState.hashKey]
+	} else {
+		entry = &(TranspositionEntry{})
+	}
+	entry.score = score
+	entry.move = move
+	entry.entryType = entryType
+	entry.depth = depth
+	boardState.transpositionTable[boardState.hashKey] = entry
 }

--- a/transpositiontable_test.go
+++ b/transpositiontable_test.go
@@ -12,9 +12,15 @@ func TestStoreAndProbe(t *testing.T) {
 	assert.Nil(t, ProbeTranspositionTable(&boardState))
 	move := Move{from: SQUARE_A1, to: SQUARE_H4, flags: CAPTURE_MASK}
 	StoreTranspositionTable(&boardState, move, 14_000, TT_EXACT, 32)
-	entry := ProbeTranspositionTable(&boardState)
 
 	assert.Equal(t,
 		TranspositionEntry{move: move, depth: 32, entryType: TT_EXACT, score: 14_000},
-		*entry)
+		*ProbeTranspositionTable(&boardState))
+
+	move = Move{from: SQUARE_B3, to: SQUARE_A8, flags: PROMOTION_MASK | CAPTURE_MASK}
+	StoreTranspositionTable(&boardState, move, -32, TT_FAIL_HIGH, -10)
+
+	assert.Equal(t,
+		TranspositionEntry{move: move, depth: -10, entryType: TT_FAIL_HIGH, score: -32},
+		*ProbeTranspositionTable(&boardState))
 }

--- a/transpositiontable_test.go
+++ b/transpositiontable_test.go
@@ -9,18 +9,22 @@ import (
 func TestStoreAndProbe(t *testing.T) {
 	boardState := CreateInitialBoardState()
 
-	assert.Nil(t, ProbeTranspositionTable(&boardState))
+	hasEntry, entry := ProbeTranspositionTable(&boardState)
+	assert.False(t, hasEntry)
 	move := Move{from: SQUARE_A1, to: SQUARE_H4, flags: CAPTURE_MASK}
 	StoreTranspositionTable(&boardState, move, 14_000, TT_EXACT, 32)
 
+	hasEntry, entry = ProbeTranspositionTable(&boardState)
+	assert.True(t, hasEntry)
 	assert.Equal(t,
 		TranspositionEntry{move: move, depth: 32, entryType: TT_EXACT, score: 14_000},
-		*ProbeTranspositionTable(&boardState))
+		entry)
 
 	move = Move{from: SQUARE_B3, to: SQUARE_A8, flags: PROMOTION_MASK | CAPTURE_MASK}
 	StoreTranspositionTable(&boardState, move, -32, TT_FAIL_HIGH, -10)
 
+	hasEntry, entry = ProbeTranspositionTable(&boardState)
 	assert.Equal(t,
 		TranspositionEntry{move: move, depth: -10, entryType: TT_FAIL_HIGH, score: -32},
-		*ProbeTranspositionTable(&boardState))
+		entry)
 }

--- a/transpositiontable_test.go
+++ b/transpositiontable_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreAndProbe(t *testing.T) {
+	boardState := CreateInitialBoardState()
+
+	assert.Nil(t, ProbeTranspositionTable(&boardState))
+	move := Move{from: SQUARE_A1, to: SQUARE_H4, flags: CAPTURE_MASK}
+	StoreTranspositionTable(&boardState, move, 14_000, TT_EXACT, 32)
+	entry := ProbeTranspositionTable(&boardState)
+
+	assert.Equal(t,
+		TranspositionEntry{move: move, depth: 32, entryType: TT_EXACT, score: 14_000},
+		*entry)
+}


### PR DESCRIPTION
No reason to re-allocate an entry if we have one, we can just reuse it.

Update - actually, let's just pack everything into a uint64.